### PR TITLE
Fix Codecov step by adding the right commit ID, PR number

### DIFF
--- a/releases/python-2104/templates/validation/code_unit_test.yaml
+++ b/releases/python-2104/templates/validation/code_unit_test.yaml
@@ -91,5 +91,10 @@ config:
         - teardown-codecov: |
             if [ "$CODECOV_TOKEN" != "" ]; then
                 $BASE_PYTHON -m pip install codecov .[test]
-                codecov
+                
+                if [ -z $SD_PULL_REQUEST ]; then
+                    codecov -c ${SD_BUILD_SHA} --build ${SD_BUILD_ID}
+                else
+                    codecov --pr ${SD_PULL_REQUEST} -c ${SD_BUILD_SHA} --build ${SD_BUILD_ID}
+                fi
             fi


### PR DESCRIPTION
Fixes #3 

## Context

Fixing the "Commit not found" in codecov dashboards by passing in the right parameters while uploading a report

## References

1. [Link to codecov CLI](https://github.com/codecov/codecov-python/blob/27a9833441ab179118716b86026e526919b2a0db/codecov/__init__.py#L403)

Codecov CLI help
```
======================== Advanced ========================:
  -X [DISABLE [DISABLE ...]], --disable [DISABLE [DISABLE ...]]
                        Disable features. Accepting **search** to disable crawling through directories, **detect** to disable detecting CI provider, **gcov** disable gcov commands, `pycov` disables running python `coverage xml`,
                        **fix** to disable report adjustments https://docs.codecov.io/docs/fixing-reports
  --root ROOT           Project directory. Default: current direcory or provided in CI environment variables
  --commit COMMIT, -c COMMIT
                        Commit SHA, set automatically
  --prefix PREFIX, -P PREFIX
                        Prefix network paths to help resolve paths: https://github.com/codecov/support/issues/472
  --branch BRANCH, -b BRANCH
                        Branch name
  --build BUILD         Specify a custom build number to distinguish CI jobs, provided automatically for supported CI companies
  --pr PR               Specify a custom pr number, provided automatically for supported CI companies
  --tag TAG             Git tag
  --tries TRIES         Specify the total number of attempts to make when uploading coverage report
```

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
