### PR TITLE
Fix package_python template by setting up deploy keys

### DIFF
--- a/releases/python-2104/templates/packaging/python.yaml
+++ b/releases/python-2104/templates/packaging/python.yaml
@@ -25,8 +25,14 @@ config:
         - TEST_PYPI_PASSWORD
         - GIT_DEPLOY_KEY
         - GIT_DEPLOY_KEY_PASSPHRASE
-    order: [begin, motd, init_os, install_dependencies, update_version, package_code, check_packages, publish, tag_release, end, teardown-store_artifacts]
+    order: [begin, motd, init_os, setup_deploy_keys, install_dependencies, update_version, package_code, check_packages, publish, tag_release, end, teardown-store_artifacts]
     steps:
+        - setup_deploy_keys: |
+            if [ ! -z "$GIT_DEPLOY_KEY" ]; then
+                screwdrivercd_ssh_setup
+                eval "$(ssh-agent -s)"
+                screwdrivercd_github_deploykey
+            fi
         - package_code: $BASE_PYTHON -m  screwdrivercd.packaging.build_python
         - check_packages: $BASE_PYTHON -m screwdrivercd.validation.validate_package_quality
         - publish: $BASE_PYTHON -m screwdrivercd.packaging.publish_python


### PR DESCRIPTION
Fixes #5 

## Context

Add `setup_deploy_key` step missing in the new template

## Objective

Without setting up deploy keys, SD builds will not be able to push tags while release. This is present in [old template](https://cd.screwdriver.cd/templates/python/package_python) but missing in the new one

## References

#5 

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
