### PR TITLE
Setup Deploy Keys in Docs template

### DIFF
--- a/releases/python-2104/templates/utility/documentation.yaml
+++ b/releases/python-2104/templates/utility/documentation.yaml
@@ -13,8 +13,14 @@ images:
     ubuntu: ubuntu:latest
 config:
     template: python-2104/base@latest
-    order: [ begin, motd, init_os, install_dependencies, update_version, publish_documentation, end, teardown-store_artifacts]
+    order: [ begin, motd, init_os, install_dependencies, setup_deploy_keys, update_version, publish_documentation, end, teardown-store_artifacts]
     steps:
+        - setup_deploy_keys: |
+            if [ ! -z "$GIT_DEPLOY_KEY" ]; then
+                screwdrivercd_ssh_setup
+                eval "$(ssh-agent -s)"
+                screwdrivercd_github_deploykey
+            fi
         - publish_documentation:
             locked: false
             command: |


### PR DESCRIPTION
## Context

@dwighthubbard 
Fixing doc publish template. Similar to #5 (Fixed Package publish in #6 )

## Objective

Python older templates consists of this steps, missing in the new templates. 
Ref: https://cd.screwdriver.cd/templates/python/documentation

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
